### PR TITLE
#15

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckMeasureComputer.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckMeasureComputer.java
@@ -1,0 +1,75 @@
+/*
+ * Dependency-Check Plugin for SonarQube
+ * Copyright (C) 2015-2017 Steve Springett
+ * steve.springett@owasp.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.dependencycheck;
+
+import org.sonar.api.ce.measure.Component.Type;
+import org.sonar.api.ce.measure.Measure;
+import org.sonar.api.ce.measure.MeasureComputer;
+import org.sonar.dependencycheck.base.DependencyCheckMetrics;
+
+/**
+ * This implementation of {@link MeasureComputer} will aggregate the metrics saved for the pom.xml files for directories, modules and projects. The metrics being summaries will be just
+ * summarized. Metrics {@link DependencyCheckMetrics#INHERITED_RISK_SCORE} and {@link DependencyCheckMetrics#VULNERABLE_COMPONENT_RATIO} are re-calculated.
+ */
+public class DependencyCheckMeasureComputer implements MeasureComputer {
+
+  @Override
+  public MeasureComputerDefinition define(MeasureComputerDefinitionContext defContext) {
+    return defContext
+        .newDefinitionBuilder()
+        .setOutputMetrics(
+            DependencyCheckMetrics.CRITICAL_SEVERITY_VULNS.getKey(),
+            DependencyCheckMetrics.HIGH_SEVERITY_VULNS.getKey(),
+            DependencyCheckMetrics.MEDIUM_SEVERITY_VULNS.getKey(),
+            DependencyCheckMetrics.LOW_SEVERITY_VULNS.getKey(),
+            DependencyCheckMetrics.TOTAL_DEPENDENCIES.getKey(),
+            DependencyCheckMetrics.VULNERABLE_DEPENDENCIES.getKey(),
+            DependencyCheckMetrics.TOTAL_VULNERABILITIES.getKey(),
+            DependencyCheckMetrics.INHERITED_RISK_SCORE.getKey(),
+            DependencyCheckMetrics.VULNERABLE_COMPONENT_RATIO.getKey())
+        .build();
+  }
+
+  @Override
+  public void compute(MeasureComputerContext context) {
+    if (context.getComponent().getType() != Type.FILE) {
+      int blocker = sumMeasure(context, DependencyCheckMetrics.CRITICAL_SEVERITY_VULNS.key());
+      int high = sumMeasure(context, DependencyCheckMetrics.HIGH_SEVERITY_VULNS.key());
+      int major = sumMeasure(context, DependencyCheckMetrics.MEDIUM_SEVERITY_VULNS.key());
+      int minor = sumMeasure(context, DependencyCheckMetrics.LOW_SEVERITY_VULNS.key());
+      sumMeasure(context, DependencyCheckMetrics.TOTAL_DEPENDENCIES.key());
+      int vulnerableDependencies = sumMeasure(context, DependencyCheckMetrics.VULNERABLE_DEPENDENCIES.key());
+      int vulnerabilityCount = sumMeasure(context, DependencyCheckMetrics.TOTAL_VULNERABILITIES.key());
+      context.addMeasure(DependencyCheckMetrics.INHERITED_RISK_SCORE.getKey(), DependencyCheckMetrics.inheritedRiskScore(blocker, high, major, minor));
+      context.addMeasure(DependencyCheckMetrics.VULNERABLE_COMPONENT_RATIO.getKey(), DependencyCheckMetrics.vulnerableComponentRatio(vulnerabilityCount, vulnerableDependencies));
+    }
+  }
+
+
+  private int sumMeasure(MeasureComputerContext context, String metricKey) {
+    int sum = 0;
+    for (Measure m : context.getChildrenMeasures(metricKey)) {
+      sum += m.getIntValue();
+    }
+    context.addMeasure(metricKey, sum);
+    return sum;
+  }
+}

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckPlugin.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckPlugin.java
@@ -35,6 +35,7 @@ public final class DependencyCheckPlugin implements Plugin {
         context.addExtensions(Arrays.asList(
                 DependencyCheckSensor.class,
                 DependencyCheckMetrics.class,
+                DependencyCheckMeasureComputer.class,
                 NeutralProfile.class,
                 NeutralLanguage.class,
                 KnownCveRuleDefinition.class,

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -79,7 +79,7 @@ public class DependencyCheckSensor implements Sensor {
         context.newIssue()
                 .forRule(RuleKey.of(DependencyCheckConstants.REPOSITORY_KEY, DependencyCheckConstants.RULE_KEY))
                 .at(new DefaultIssueLocation()
-                        .on(context.module())
+                        .on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml")))
                         .message(formatDescription(dependency, vulnerability))
                 )
                 .overrideSeverity(severity)
@@ -96,7 +96,7 @@ public class DependencyCheckSensor implements Sensor {
         context.newIssue()
             .forRule(RuleKey.of(DependencyCheckConstants.REPOSITORY_KEY, DependencyCheckConstants.RULE_KEY))
             .at(new DefaultIssueLocation()
-                .on(context.module())
+                .on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml")))
                 .message(formatDescription(dependency, vulnerabilities, highestVulnerability)))
             .overrideSeverity(severity)
             .save();
@@ -200,18 +200,18 @@ public class DependencyCheckSensor implements Sensor {
     }
 
     private void saveMeasures(SensorContext context) {
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.CRITICAL_SEVERITY_VULNS).on(context.module()).withValue(blockerIssuesCount).save();
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.HIGH_SEVERITY_VULNS).on(context.module()).withValue(criticalIssuesCount).save();
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.MEDIUM_SEVERITY_VULNS).on(context.module()).withValue(majorIssuesCount).save();
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.LOW_SEVERITY_VULNS).on(context.module()).withValue(minorIssuesCount).save();
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.TOTAL_DEPENDENCIES).on(context.module()).withValue(totalDependencies).save();
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.VULNERABLE_DEPENDENCIES).on(context.module()).withValue(vulnerableDependencies).save();
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.TOTAL_VULNERABILITIES).on(context.module()).withValue(vulnerabilityCount).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.CRITICAL_SEVERITY_VULNS).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(blockerIssuesCount).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.HIGH_SEVERITY_VULNS).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(criticalIssuesCount).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.MEDIUM_SEVERITY_VULNS).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(majorIssuesCount).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.LOW_SEVERITY_VULNS).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(minorIssuesCount).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.TOTAL_DEPENDENCIES).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(totalDependencies).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.VULNERABLE_DEPENDENCIES).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(vulnerableDependencies).save();
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.TOTAL_VULNERABILITIES).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(vulnerabilityCount).save();
         LOGGER.debug("Found {} info Issues", infoIssuesCount);
 
-        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.INHERITED_RISK_SCORE).on(context.module())
+        context.<Integer>newMeasure().forMetric(DependencyCheckMetrics.INHERITED_RISK_SCORE).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml")))
             .withValue(DependencyCheckMetrics.inheritedRiskScore(blockerIssuesCount, criticalIssuesCount, majorIssuesCount, minorIssuesCount)).save();
-        context.<Double>newMeasure().forMetric(DependencyCheckMetrics.VULNERABLE_COMPONENT_RATIO).on(context.module())
+        context.<Double>newMeasure().forMetric(DependencyCheckMetrics.VULNERABLE_COMPONENT_RATIO).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml")))
             .withValue(DependencyCheckMetrics.vulnerableComponentRatio(vulnerabilityCount, vulnerableDependencies)).save();
 
         try {
@@ -219,7 +219,7 @@ public class DependencyCheckSensor implements Sensor {
             String htmlReport = htmlReportFile.getReportContent();
             if (htmlReport != null) {
                 LOGGER.info("Upload Dependency-Check HTML-Report");
-                context.<String>newMeasure().forMetric(DependencyCheckMetrics.REPORT).on(context.module()).withValue(htmlReport).save();
+                context.<String>newMeasure().forMetric(DependencyCheckMetrics.REPORT).on(context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml"))).withValue(htmlReport).save();
             }
         } catch (FileNotFoundException e) {
             LOGGER.info(e.getMessage());


### PR DESCRIPTION
This should be the fix for the problem. The cause of the missing aggregation is that this should be done by a MeasureComputer which is missing. Once you have this you can aggregate metrics on directory, module and project level. You just need to collect the metrics of the children.
 Therefore I changed the creation of the metrics to be on the pom.xml and not the module. Adding metrics to modules will be deprecated anyway.

You can also have look at [mathan-dependency-updates-sonar-plugin](https://github.com/reallyinsane/mathan-dependency-updates-sonar-plugin) which had the same problem.

