### PR TITLE
Quick fix for #140

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -46,7 +46,7 @@ public class DependencyCheckSensor implements ProjectSensor {
     private static final Logger LOGGER = Loggers.get(DependencyCheckSensor.class);
     private static final String SENSOR_NAME = "Dependency-Check";
     private static final String[] XSD = {"https://jeremylong.github.io/DependencyCheck/dependency-check.1.8.xsd",
-    "https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd"};
+    "https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd", "https://jeremylong.github.io/DependencyCheck/dependency-check.2.1.xsd"};
 
     private final FileSystem fileSystem;
     private final PathResolver pathResolver;


### PR DESCRIPTION
It looks like the fix for this problem is relatively simple.  The alternative is to roll back to an older version of the dependency-check plugin which is undesirable.