### PR TITLE
[examples] add nodejs examples

### DIFF
--- a/examples/single-module-nodejs/README.md
+++ b/examples/single-module-nodejs/README.md
@@ -35,7 +35,7 @@ jquery@2.2.0 => vulnerabilities moderate and high from NPM AND vulnerabilities M
 Copyright & License
 -------------------
 
-Dependency-Check Sonar Plugin is Copyright (c) Steve Springett. All Rights Reserved.
+Dependency-Check Sonar Plugin is Copyright (c) SonarSecurityCommunity. All Rights Reserved.
 
 Dependency-Check is Copyright (c) Jeremy Long. All Rights Reserved.
 

--- a/examples/single-module-nodejs/README.md
+++ b/examples/single-module-nodejs/README.md
@@ -1,0 +1,45 @@
+
+Example Single Module Nodejs Project
+=====================================
+
+Integrates [Dependency-Check] analysis and reporting into SonarQube v6.7 or higher in a single module (flat) Nodejs project.
+
+Usage
+-------------------
+Install dependencies
+```
+npm install
+```
+
+if you want to use it fastly :
+Use the `command-line-project` :
+```
+mkdir ../command-line-project/lib
+cp * ../command-line-project/lib
+cd ../command-line-project/lib
+npm install
+cd ..
+./build.sh
+```
+
+Dependencies with vulnerabilities
+-------------------
+
+braces@2.3.0 => vulnerability low from NPM
+lodash@4.17.10 => vulnerability moderate from NPM
+open@0.0.5 => vulnerability critical from NPM
+tar@4.4.0 => vulnerability high from NPM
+jquery@2.2.0 => vulnerabilities moderate and high from NPM AND vulnerabilities MEDIUM (multiple times) from NVD
+
+
+Copyright & License
+-------------------
+
+Dependency-Check Sonar Plugin is Copyright (c) Steve Springett. All Rights Reserved.
+
+Dependency-Check is Copyright (c) Jeremy Long. All Rights Reserved.
+
+Permission to modify and redistribute is granted under the terms of the [LGPLv3] license.
+
+  [LGPLv3]: http://www.gnu.org/licenses/lgpl.txt
+  [Dependency-Check]: https://www.owasp.org/index.php/OWASP_Dependency_Check

--- a/examples/single-module-nodejs/package.json
+++ b/examples/single-module-nodejs/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "single-module-nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "braces": "2.3.0",
+    "lodash": "4.17.10",
+    "open": "0.0.5",
+    "jquery": "2.2.0",
+    "tar": "4.4.0"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Here is a package.json for example, to generate nodejs reports .

I've had multiple dependencies, with vulnerabilities : 
```
braces@2.3.0 => vulnerability low from NPM
lodash@4.17.10 => vulnerability moderate from NPM
open@0.0.5 => vulnerability critical from NPM
tar@4.4.0 => vulnerability high from NPM
jquery@2.2.0 => vulnerabilities moderate and high from NPM AND vulnerabilities MEDIUM (multiple times) from NVD
```
The four first are here to try the differents level of vulnerabilities reported by NPM ...

The jquery seems to be a good example, because it produce lot of vulnerabilities in the report xD . ( 2 NPM vulnerabilities, and 4 NVD vulnerabilities, on three differents files )
