### PR TITLE
Add plugin version compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Distribution
 -------------------
 Ready to use binaries are available from [GitHub] and [bintray].
 
+Plugin version compatibility
+-------------------
+Plugin Version | SonarQube version
+----------------- | --------------
+1.0.3 | SonarQube 5.2 - 6.2
+1.1.0 | SonarQube 6.3 - 6.7.4
+1.1.1 | SonarQube 6.3 - 6.7.4
+1.1.2 | SonarQube 6.7.5 - 7.2.1
+1.1.3 | SonarQube 6.7.5 - 7.2.1
+1.1.4 | SonarQube 6.7.5 - 7.2.1
+1.2.0 | SonarQube 7.3 - 7.5
+1.2.1 | SonarQube 7.3 - 7.5
+1.2.2 | SonarQube 7.6 - up
+1.2.3 | SonarQube 7.6 - up
+
 Installation
 -------------------
 Copy the plugin (jar file) to $SONAR_INSTALL_DIR/extensions/plugins and restart SonarQube.

--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ Plugin version compatibility
 -------------------
 Plugin Version | SonarQube version
 ----------------- | --------------
-1.0.3 | SonarQube 5.2 - 6.2
-1.1.0 | SonarQube 6.3 - 6.7.4
-1.1.1 | SonarQube 6.3 - 6.7.4
-1.1.2 | SonarQube 6.7.5 - 7.2.1
-1.1.3 | SonarQube 6.7.5 - 7.2.1
-1.1.4 | SonarQube 6.7.5 - 7.2.1
-1.2.0 | SonarQube 7.3 - 7.5
+1.2.3 | SonarQube 7.6 and up
+1.2.2 | SonarQube 7.6 and up
 1.2.1 | SonarQube 7.3 - 7.5
-1.2.2 | SonarQube 7.6 - up
-1.2.3 | SonarQube 7.6 - up
+1.2.0 | SonarQube 7.3 - 7.5
+1.1.4 | SonarQube 6.7.5 - 7.2.1
+1.1.3 | SonarQube 6.7.5 - 7.2.1
+1.1.2 | SonarQube 6.7.5 - 7.2.1
+1.1.1 | SonarQube 6.3 - 6.7.4
+1.1.0 | SonarQube 6.3 - 6.7.4
+1.0.3 | SonarQube 5.2 - 6.2
 
 Installation
 -------------------


### PR DESCRIPTION
This list is created based on versions mentioned in github releases, where I am assuming that when a new minimum sonarqube version number is mentioned, the previous version of the plugin is no longer compatible starting from that version.