### PR TITLE
Use $@ which can be safely quoted for input args

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
 export PATH=JAVA_HOME/bin:$PATH
 
-mvn clean install $*
+mvn clean install "$@"
 


### PR DESCRIPTION
Just noticed $* usage, which would flatten script args and split them on spaces